### PR TITLE
Change of name and url for TEST4U

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -44,7 +44,7 @@ title: Resources and guides
 	<li><strong><a href="http://www.funlearning.com" target="_blank">Angry Birds Fun Learning</a></strong>: Learn to code the fun way! Discover fun coding apps and courses for various difficulty levels.</li>
 	<li><strong><a href="https://webmaker.org/" target="_blank">Webmaker Web Literacy Map</a></strong>: A collection of resources for teaching and learning digital skills and web literacy, including a section on creating for the web.</li>
 	<li><strong><a href="http://www.w3schools.com" target="_blank">W3Schools Online Web Tutorials</a></strong>: A collection of tutorials and references for web-related languages.</li>
-	<li><strong><a href="http://www.test4u.eu/en/codeweek" target="_blank">TEST4U</a></strong>: A collection of interactive tutorials for HTML, CSS, JavaScript, PHP and MySQL.</li>
+	<li><strong><a href="http://www.academy-of-code.com/en" target="_blank">Academy of Code</a></strong>: A collection of free interactive tutorials for HTML, CSS, JavaScript, PHP and MySQL.</li>
 	<li><strong><a href="http://www.codingame.com" target="_blank">CodinGame</a></strong>: Play video games using code, learn programming in more than 20 programming languages.</li>
 	<li><strong><a href="http://silentteacher.toxicode.fr" target="_blank">Silent Teacher</a></strong>: a step by step and funny way to learn the basics.</li>
 	<li><strong><a href="https://codecombat.com" target="_blank">CodeCombat</a></strong>: an online game that teaches programming. Students write code in real programming languages (Python, JavaScript, Lua, CofeeScript, Clojure).</li>


### PR DESCRIPTION
The free online web lessons from TEST4U now have their own home and url in www.academy-of-code.com/en